### PR TITLE
chore: configure linting and Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: 'npm' }
-      - run: npm ci
+        with: { node-version: 20, cache: 'npm', registry-url: 'https://registry.npmjs.org' }
+      - run: npm ci --no-audit --fund=false
       - run: npm run check
       - run: npm run build -- --base=/${{ github.event.repository.name }}/
       - run: cp dist/index.html dist/404.html

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+registry=https://registry.npmjs.org/
+@eslint:registry=https://registry.npmjs.org/
+strict-ssl=true
+fund=false
+audit=false

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,3 @@
-// eslint.config.js
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import react from 'eslint-plugin-react';
@@ -8,57 +7,35 @@ import importPlugin from 'eslint-plugin-import';
 
 export default tseslint.config(
   { ignores: ['dist', 'build', 'node_modules'] },
-
-  // Base JS rules
   js.configs.recommended,
-
-  // TS rules (type-aware)
   ...tseslint.configs.recommendedTypeChecked,
-
-  // Project config
   {
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {
-        project: true,                 // auto-detect tsconfig.json
+        project: true,
         tsconfigRootDir: import.meta.dirname,
         ecmaVersion: 'latest',
-        sourceType: 'module'
+        sourceType: 'module',
       },
-      globals: {
-        window: 'readonly',
-        document: 'readonly',
-        navigator: 'readonly'
-      }
+      globals: { window: 'readonly', document: 'readonly', navigator: 'readonly' },
     },
-    plugins: {
-      react,
-      'react-hooks': reactHooks,
-      'jsx-a11y': jsxA11y,
-      import: importPlugin
-    },
+    plugins: { react, 'react-hooks': reactHooks, 'jsx-a11y': jsxA11y, import: importPlugin },
     settings: { react: { version: 'detect' } },
     rules: {
-      // React (React 17+ JSX runtime)
       'react/react-in-jsx-scope': 'off',
       'react/jsx-uses-react': 'off',
-
-      // Hooks
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
-
-      // Import hygiene
-      'import/order': ['warn', {
-        'newlines-between': 'always',
-        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index']
-      }],
-
-      // TS strictness
+      'import/order': [
+        'warn',
+        {
+          'newlines-between': 'always',
+          groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+        },
+      ],
       '@typescript-eslint/no-floating-promises': 'warn',
       '@typescript-eslint/await-thenable': 'warn',
-
-      // Keep Prettier last to disable conflicting stylistic rules
-      'prettier/prettier': 'off'
-    }
+    },
   }
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 import { defineConfig } from 'vite';
 
-export default defineConfig(() => ({
-  base: process.env.VITE_BASE || '/REPO_NAME/',
+export default defineConfig(({ mode }) => ({
+  base: process.env.VITE_BASE || '/REPO_NAME/', // GH Pages will override
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- add npm registry config
- streamline ESLint flat config
- set Vite base path and update Pages workflow

## Testing
- `npm run check` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'tailwindcss')*
- `cp dist/index.html dist/404.html` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b3b9a2488325af26b2aed78cb4f9